### PR TITLE
Add note field for records

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -33,6 +33,7 @@ class _RecordListPageState extends State<RecordListPage> {
   void _addRecord() {
     final investmentController = TextEditingController();
     final returnController = TextEditingController();
+    final noteController = TextEditingController();
     showDialog(
       context: context,
       builder: (context) {
@@ -53,6 +54,11 @@ class _RecordListPageState extends State<RecordListPage> {
                 keyboardType: TextInputType.number,
                 decoration: const InputDecoration(labelText: 'Return'),
               ),
+              TextField(
+                key: const Key('noteField'),
+                controller: noteController,
+                decoration: const InputDecoration(labelText: 'Note'),
+              ),
             ],
           ),
           actions: [
@@ -68,6 +74,7 @@ class _RecordListPageState extends State<RecordListPage> {
                   _records.add(Record(
                     investment: investment,
                     returnAmount: returnAmount,
+                    note: noteController.text,
                   ));
                 });
                 Navigator.of(context).pop();
@@ -92,7 +99,14 @@ class _RecordListPageState extends State<RecordListPage> {
                 final record = _records[index];
                 return ListTile(
                   title: Text('Investment: \$${record.investment}, Return: \$${record.returnAmount}'),
-                  subtitle: Text('Profit: \$${record.profit}'),
+                  subtitle: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text('Profit: \$${record.profit}'),
+                      if (record.note != null && record.note!.isNotEmpty)
+                        Text('Note: ${record.note}')
+                    ],
+                  ),
                 );
               },
             ),

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -14,11 +14,13 @@ void main() {
 
     await tester.enterText(find.byKey(const Key('investmentField')), '1000');
     await tester.enterText(find.byKey(const Key('returnField')), '1500');
+    await tester.enterText(find.byKey(const Key('noteField')), 'test note');
 
     await tester.tap(find.text('Save'));
     await tester.pumpAndSettle();
 
     expect(find.textContaining('Investment: \$1000'), findsOneWidget);
     expect(find.textContaining('Profit: \$500'), findsOneWidget);
+    expect(find.textContaining('Note: test note'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- allow entering an optional note when adding records
- show note in record list
- test note entry and display

## Testing
- `dart format lib/main.dart test/widget_test.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `apt-get update >/tmp/apt_update.log && tail -n 20 /tmp/apt_update.log` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bd6366b4d48333b14fc9dad37517f2