### PR TITLE
Add note field to records

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -38,6 +38,7 @@ class _RecordListPageState extends State<RecordListPage> {
   void _addRecord() {
     final investmentController = TextEditingController();
     final returnController = TextEditingController();
+    final noteController = TextEditingController();
     showDialog(
       context: context,
       builder: (context) {
@@ -58,6 +59,11 @@ class _RecordListPageState extends State<RecordListPage> {
                 keyboardType: TextInputType.number,
                 decoration: const InputDecoration(labelText: 'Return'),
               ),
+              TextField(
+                key: const Key('noteField'),
+                controller: noteController,
+                decoration: const InputDecoration(labelText: 'Note'),
+              ),
             ],
           ),
           actions: [
@@ -69,11 +75,13 @@ class _RecordListPageState extends State<RecordListPage> {
               onPressed: () {
                 final investment = int.tryParse(investmentController.text) ?? 0;
                 final returnAmount = int.tryParse(returnController.text) ?? 0;
+                final note = noteController.text;
                 setState(() {
                   _records.add(Record(
                     date: _selectedDate,
                     investment: investment,
                     returnAmount: returnAmount,
+                    note: note.isEmpty ? null : note,
                   ));
                 });
                 Navigator.of(context).pop();
@@ -114,7 +122,14 @@ class _RecordListPageState extends State<RecordListPage> {
                       return ListTile(
                         title: Text(
                             'Investment: \$${record.investment}, Return: \$${record.returnAmount}'),
-                        subtitle: Text('Profit: \$${record.profit}'),
+                        subtitle: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text('Profit: \$${record.profit}'),
+                            if (record.note != null)
+                              Text('Note: ${record.note}')
+                          ],
+                        ),
                       );
                     },
                   ),

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -14,11 +14,13 @@ void main() {
 
     await tester.enterText(find.byKey(const Key('investmentField')), '1000');
     await tester.enterText(find.byKey(const Key('returnField')), '1500');
+    await tester.enterText(find.byKey(const Key('noteField')), 'Good day');
 
     await tester.tap(find.text('Save'));
     await tester.pumpAndSettle();
 
     expect(find.textContaining('Investment: \$1000'), findsOneWidget);
     expect(find.textContaining('Profit: \$500'), findsOneWidget);
+    expect(find.textContaining('Note: Good day'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- allow users to add an optional note when creating records
- display record notes beneath profit in list
- extend widget test to cover note input and display

## Testing
- `flutter test` *(fails: command not found)*
- `dart format lib/main.dart test/widget_test.dart` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68bd64f0d5b883338b9f899d585e477b