### PR TITLE
feat: show daily summary

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -98,6 +98,11 @@ class _RecordListPageState extends State<RecordListPage> {
   Widget build(BuildContext context) {
     final dayRecords =
         _records.where((r) => _isSameDay(r.date, _selectedDate)).toList();
+    final totalInvestment =
+        dayRecords.fold<int>(0, (sum, r) => sum + r.investment);
+    final totalReturn =
+        dayRecords.fold<int>(0, (sum, r) => sum + r.returnAmount);
+    final totalProfit = totalReturn - totalInvestment;
     return Scaffold(
       appBar: AppBar(title: const Text('Records')),
       body: Column(
@@ -133,6 +138,11 @@ class _RecordListPageState extends State<RecordListPage> {
                       );
                     },
                   ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: Text(
+                'Total Investment: \$${totalInvestment}, Total Return: \$${totalReturn}, Total Profit: \$${totalProfit}'),
           ),
         ],
       ),

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -8,6 +8,7 @@ void main() {
     await tester.pumpWidget(const PsLogApp());
 
     expect(find.byType(ListTile), findsNothing);
+    expect(find.textContaining('Total Profit: \$0'), findsOneWidget);
 
     await tester.tap(find.byType(FloatingActionButton));
     await tester.pumpAndSettle();
@@ -22,5 +23,6 @@ void main() {
     expect(find.textContaining('Investment: \$1000'), findsOneWidget);
     expect(find.textContaining('Profit: \$500'), findsOneWidget);
     expect(find.textContaining('Note: Good day'), findsOneWidget);
+    expect(find.textContaining('Total Profit: \$500'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- display daily totals for investment, return, and profit
- test summary updates after adding a record

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd6596f7f8833394ef777440333bf8