### PR TITLE
記録に開始・終了時刻を追加し日本語化

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -38,12 +38,14 @@ class _RecordListPageState extends State<RecordListPage> {
   void _addRecord() {
     final investmentController = TextEditingController();
     final returnController = TextEditingController();
+    final startController = TextEditingController();
+    final endController = TextEditingController();
     final noteController = TextEditingController();
     showDialog(
       context: context,
       builder: (context) {
         return AlertDialog(
-          title: const Text('Add Record'),
+          title: const Text('記録を追加'),
           content: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
@@ -51,42 +53,88 @@ class _RecordListPageState extends State<RecordListPage> {
                 key: const Key('investmentField'),
                 controller: investmentController,
                 keyboardType: TextInputType.number,
-                decoration: const InputDecoration(labelText: 'Investment'),
+                decoration: const InputDecoration(labelText: '投資額'),
               ),
               TextField(
                 key: const Key('returnField'),
                 controller: returnController,
                 keyboardType: TextInputType.number,
-                decoration: const InputDecoration(labelText: 'Return'),
+                decoration: const InputDecoration(labelText: '回収額'),
+              ),
+              TextField(
+                key: const Key('startField'),
+                controller: startController,
+                keyboardType: TextInputType.datetime,
+                decoration: const InputDecoration(labelText: '開始時間 (HH:mm)'),
+              ),
+              TextField(
+                key: const Key('endField'),
+                controller: endController,
+                keyboardType: TextInputType.datetime,
+                decoration: const InputDecoration(labelText: '終了時間 (HH:mm)'),
               ),
               TextField(
                 key: const Key('noteField'),
                 controller: noteController,
-                decoration: const InputDecoration(labelText: 'Note'),
+                decoration: const InputDecoration(labelText: 'メモ'),
               ),
             ],
           ),
           actions: [
             TextButton(
               onPressed: () => Navigator.of(context).pop(),
-              child: const Text('Cancel'),
+              child: const Text('キャンセル'),
             ),
             TextButton(
               onPressed: () {
                 final investment = int.tryParse(investmentController.text) ?? 0;
                 final returnAmount = int.tryParse(returnController.text) ?? 0;
+                DateTime? startTime;
+                DateTime? endTime;
+                if (startController.text.isNotEmpty) {
+                  final parts = startController.text.split(':');
+                  if (parts.length == 2) {
+                    final h = int.tryParse(parts[0]);
+                    final m = int.tryParse(parts[1]);
+                    if (h != null && m != null) {
+                      startTime = DateTime(
+                          _selectedDate.year,
+                          _selectedDate.month,
+                          _selectedDate.day,
+                          h,
+                          m);
+                    }
+                  }
+                }
+                if (endController.text.isNotEmpty) {
+                  final parts = endController.text.split(':');
+                  if (parts.length == 2) {
+                    final h = int.tryParse(parts[0]);
+                    final m = int.tryParse(parts[1]);
+                    if (h != null && m != null) {
+                      endTime = DateTime(
+                          _selectedDate.year,
+                          _selectedDate.month,
+                          _selectedDate.day,
+                          h,
+                          m);
+                    }
+                  }
+                }
                 final note = noteController.text;
                 setState(() {
                   _records.add(Record(
                     date: _selectedDate,
                     investment: investment,
                     returnAmount: returnAmount,
+                    startTime: startTime,
+                    endTime: endTime,
                     note: note.isEmpty ? null : note,
                   ));
                 });
                 Navigator.of(context).pop();
               },
-              child: const Text('Save'),
+              child: const Text('保存'),
             ),
           ],
         );
@@ -99,7 +147,7 @@ class _RecordListPageState extends State<RecordListPage> {
     final dayRecords =
         _records.where((r) => _isSameDay(r.date, _selectedDate)).toList();
     return Scaffold(
-      appBar: AppBar(title: const Text('Records')),
+      appBar: AppBar(title: const Text('記録一覧')),
       body: Column(
         children: [
           CalendarDatePicker(
@@ -114,20 +162,25 @@ class _RecordListPageState extends State<RecordListPage> {
           ),
           Expanded(
             child: dayRecords.isEmpty
-                ? const Center(child: Text('No records for selected day'))
+                ? const Center(child: Text('選択した日に記録はありません'))
                 : ListView.builder(
                     itemCount: dayRecords.length,
                     itemBuilder: (context, index) {
                       final record = dayRecords[index];
+                      String _formatTime(DateTime t) =>
+                          '${t.hour.toString().padLeft(2, '0')}:${t.minute.toString().padLeft(2, '0')}';
                       return ListTile(
                         title: Text(
-                            'Investment: \$${record.investment}, Return: \$${record.returnAmount}'),
+                            '投資: ${record.investment}円, 回収: ${record.returnAmount}円'),
                         subtitle: Column(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
-                            Text('Profit: \$${record.profit}'),
+                            Text('収支: ${record.profit}円'),
+                            if (record.startTime != null && record.endTime != null)
+                              Text(
+                                  '開始: ${_formatTime(record.startTime!)}, 終了: ${_formatTime(record.endTime!)}'),
                             if (record.note != null)
-                              Text('Note: ${record.note}')
+                              Text('メモ: ${record.note}')
                           ],
                         ),
                       );
@@ -138,7 +191,7 @@ class _RecordListPageState extends State<RecordListPage> {
       ),
       floatingActionButton: FloatingActionButton(
         onPressed: _addRecord,
-        tooltip: 'Add Record',
+        tooltip: '記録を追加',
         child: const Icon(Icons.add),
       ),
     );

--- a/lib/record.dart
+++ b/lib/record.dart
@@ -1,15 +1,38 @@
+/// 1件の稼働記録を表すクラス
 class Record {
+  /// 日付
   final DateTime date;
+
+  /// 投資額（円）
   final int investment;
+
+  /// 回収額（円）
   final int returnAmount;
+
+  /// 開始時刻
+  final DateTime? startTime;
+
+  /// 終了時刻
+  final DateTime? endTime;
+
+  /// メモ
   final String? note;
 
   const Record({
     required this.date,
     required this.investment,
     required this.returnAmount,
+    this.startTime,
+    this.endTime,
     this.note,
   });
 
+  /// 収支（回収額 − 投資額）
   int get profit => returnAmount - investment;
+
+  /// 稼働時間
+  Duration? get duration {
+    if (startTime == null || endTime == null) return null;
+    return endTime!.difference(startTime!);
+  }
 }

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -4,7 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:ps_log/main.dart';
 
 void main() {
-  testWidgets('Adding a record displays it in the list', (WidgetTester tester) async {
+  testWidgets('記録を追加すると一覧に表示される', (WidgetTester tester) async {
     await tester.pumpWidget(const PsLogApp());
 
     expect(find.byType(ListTile), findsNothing);
@@ -14,13 +14,13 @@ void main() {
 
     await tester.enterText(find.byKey(const Key('investmentField')), '1000');
     await tester.enterText(find.byKey(const Key('returnField')), '1500');
-    await tester.enterText(find.byKey(const Key('noteField')), 'Good day');
+    await tester.enterText(find.byKey(const Key('noteField')), '良い日');
 
-    await tester.tap(find.text('Save'));
+    await tester.tap(find.text('保存'));
     await tester.pumpAndSettle();
 
-    expect(find.textContaining('Investment: \$1000'), findsOneWidget);
-    expect(find.textContaining('Profit: \$500'), findsOneWidget);
-    expect(find.textContaining('Note: Good day'), findsOneWidget);
+    expect(find.textContaining('投資: 1000円'), findsOneWidget);
+    expect(find.textContaining('収支: 500円'), findsOneWidget);
+    expect(find.textContaining('メモ: 良い日'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## 概要
- 記録データに開始・終了時刻を追加
- 一覧に開始・終了時刻と収支を日本語で表示
- テストを日本語化し、記録追加が表示されることを確認

## テスト
- `flutter test` (flutter: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68bd663f067083338742a1681de4a6ba