### PR TITLE
合計表示の日本語化

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -194,8 +194,9 @@ class _RecordListPageState extends State<RecordListPage> {
           ),
           Padding(
             padding: const EdgeInsets.all(16),
+            // 当日の合計投資額・回収額・収支を表示
             child: Text(
-                'Total Investment: \$${totalInvestment}, Total Return: \$${totalReturn}, Total Profit: \$${totalProfit}'),
+                '総投資額: ${totalInvestment}円, 総回収額: ${totalReturn}円, 総収支: ${totalProfit}円'),
           ),
         ],
       ),

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -8,7 +8,7 @@ void main() {
     await tester.pumpWidget(const PsLogApp());
 
     expect(find.byType(ListTile), findsNothing);
-    expect(find.textContaining('Total Profit: \$0'), findsOneWidget);
+    expect(find.textContaining('総収支: 0円'), findsOneWidget);
 
     await tester.tap(find.byType(FloatingActionButton));
     await tester.pumpAndSettle();


### PR DESCRIPTION
## 概要
- 合計投資額・回収額・収支の文言を日本語表記に変更
- ウィジェットテストを文言変更に合わせて更新

## テスト
- `flutter test` (command not found)
- `dart test` (command not found)


------
https://chatgpt.com/codex/tasks/task_e_68bd68e5ebfc8333832269dcc47fb7f4